### PR TITLE
Lodash is no longer maintained.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "commander": "^2.8.1",
     "crypto-js": "^3.1.2-5",
     "debug": "^2.2.0",
-    "lodash": "2.4.1",
+    "lodash": "^4.0.0",
     "readline-sync": "^1.2.21",
     "request": "2.51.0",
     "xml2js": "0.4.4"


### PR DESCRIPTION
```
npm WARN deprecated lodash@2.4.1: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^4.0.0.
```